### PR TITLE
Updating version number in platformio manifest

### DIFF
--- a/library.json
+++ b/library.json
@@ -6,7 +6,7 @@
     "type": "git",
     "url": "https://github.com/panStamp/thermistor.git"
   },
-  "version": "1.0.2",
+  "version": "1.0.3",
   "frameworks": "arduino",
   "platforms": "*"
 }


### PR DESCRIPTION
Both master and 1.0.3 tag have a discrepancy between the version number in`library.json` and `library.properties`. It's correctly set to `1.0.3` in `library.properties`, but left as `1.0.2` in `library.json`

The impact of this is that you can't install the 1.0.3 version of the library (with ESP32 compatibility)  using the platformio package manger.

This update is also needed in the 1.0.3 tag.